### PR TITLE
Fix examples & make them runnable

### DIFF
--- a/examples/file1.txt
+++ b/examples/file1.txt
@@ -1,0 +1,15 @@
+Duis veniam commodo reprehenderit sint occaecat in sed anim veniam qui
+exercitation ut qui est cupidatat sint velit laboris ut eu enim consectetur amet
+tempor sit sed fugiat quis id exercitation reprehenderit eu voluptate laborum
+aliqua dolor irure magna aliqua amet commodo dolore aliquip commodo nostrud
+laborum Excepteur fugiat dolor exercitation nostrud laborum velit quis nisi
+Excepteur in minim sunt enim dolore proident sit do reprehenderit nulla id anim
+reprehenderit dolor ullamco elit sed cillum adipisicing reprehenderit aliquip
+ullamco Excepteur incididunt culpa aliquip velit consequat adipisicing eiusmod
+esse esse cillum commodo adipisicing ut qui quis dolor aliqua cupidatat
+Excepteur enim tempor in Ut reprehenderit deserunt voluptate in sed enim
+incididunt ad ex voluptate incididunt et laboris consequat Ut dolore incididunt
+velit ullamco minim nisi ut exercitation enim tempor occaecat anim nostrud
+veniam exercitation in Excepteur incididunt cupidatat ea irure mollit aliqua
+officia commodo incididunt ex consectetur nulla ullamco minim do magna pariatur
+esse laborum elit.

--- a/examples/file2.txt
+++ b/examples/file2.txt
@@ -1,0 +1,6 @@
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.

--- a/examples/pack-tgz.js
+++ b/examples/pack-tgz.js
@@ -14,8 +14,8 @@ archive.on('error', function(err) {
 
 archive.pipe(gzipper).pipe(out);
 
-async.forEachSeries(['file1.js', 'file2.js'], function(file, next) {
-  archive.addFile(fs.createReadStream(file), { name: file }, next);
+async.forEachSeries(['file1.txt', 'file2.txt'], function(file, cb) {
+  archive.addFile(fs.createReadStream(file), { name: file }, cb);
 }, function(err) {
   if (err) {
     throw err;

--- a/examples/pack.js
+++ b/examples/pack.js
@@ -12,8 +12,8 @@ archive.on('error', function(err) {
 
 archive.pipe(out);
 
-async.forEachSeries(['file1.js', 'file2.js'], function(file, next) {
-  archive.addFile(fs.createReadStream(file), { name: file }, next);
+async.forEachSeries(['file1.txt', 'file2.txt'], function(file, cb) {
+  archive.addFile(fs.createReadStream(file), { name: file }, cb);
 }, function(err) {
   if (err) {
     throw err;


### PR DESCRIPTION
The examples were using `async.forEach` as a way to asynchronously iterate over the files to add them in the archives. This is problematic because the library expects one file packaging to be over before calling `.addFile` again.

Using `async.forEachSeries` fixes this, because it iterates in series, not in parallel.

The second commit includes two sample files, so the examples are runnable straight away.

See #10 also.
