### PR TITLE
move rimfar and mkdirp to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "dependencies": {
     "readable-stream": "~0.2.0",
-    "lodash": "~0.10.0",
-    "rimraf": "~2.1.2",
-    "mkdirp": "~0.3.4"
+    "lodash": "~0.10.0"
   },
   "devDependencies": {
-    "nodeunit": "~0.7.4"
+    "nodeunit": "~0.7.4",
+    "rimraf": "~2.1.2",
+    "mkdirp": "~0.3.4"
   },
   "keywords": [
     "archive",


### PR DESCRIPTION
Although they should be called before or after tests run. ie on `moduleDone`, or `moduleStart` (in nodeunit terms, which I'm not used to).

But anyway, that's a start.
