### PR TITLE
add benchmark pack-zip-simple

### DIFF
--- a/benchmark/pack-zip-simple.js
+++ b/benchmark/pack-zip-simple.js
@@ -1,0 +1,17 @@
+var archiver    = require('../')
+  , streamBench = require('stream-bench')
+  , fs          = require('fs')
+
+var archive = archiver.create('zip')
+
+archive
+  .addFile(fs.createReadStream(process.argv[2]), { name: 'large file' })
+  .finalize()
+
+var bench = streamBench({
+  logReport: true,
+  interval:  500,
+  dump:      true
+})
+
+archive.pipe(bench)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "devDependencies": {
     "nodeunit": "~0.7.4",
     "rimraf": "~2.1.2",
-    "mkdirp": "~0.3.4"
+    "mkdirp": "~0.3.4",
+    "stream-bench": "~0.1.2"
   },
   "keywords": [
     "archive",


### PR DESCRIPTION
Wrote [stream-bench](https://github.com/danmilon/stream-bench) so we can finally get some metrics. It calculates throughput.

run with

```
node benchmark/pack-zip-simple.js PATH_TO_BIG_FILE
```

Feel free to add `USAGE` sugar if you think it's necessary.
