### PR TITLE
core: kill queues also after finalize, not only on abort

### DIFF
--- a/lib/modules/core/index.js
+++ b/lib/modules/core/index.js
@@ -42,8 +42,7 @@ var Archiver = module.exports = function(options) {
 inherits(Archiver, Transform);
 
 Archiver.prototype._abort = function() {
-  this._queue.kill();
-  this._statQueue.kill();
+  this._killQueues();
   this._state.aborted = true;
 };
 
@@ -87,6 +86,7 @@ Archiver.prototype._moduleFinalize = function() {
 
   this._state.finalizing = false;
   this._state.finalized = true;
+  this._killQueues();
 };
 
 Archiver.prototype._moduleSupports = function(key) {
@@ -195,6 +195,11 @@ Archiver.prototype._onStatQueueTask = function(task, callback) {
       return;
     }
   }.bind(this));
+};
+
+Archiver.prototype._killQueues = function() {
+  this._queue.kill();
+  this._statQueue.kill();
 };
 
 Archiver.prototype._updateQueueTaskWithStats = function(task, stats) {


### PR DESCRIPTION
We are having a memory leak after running the archiver many times and found that queues are not being killed on finalize, only on abort. So I added this, creating the branch from commit b759789 (release 0.12.0).
If the fix is good for you, could release it as version 0.12.1?

Thank you