### PR TITLE
fix `date` options

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -167,7 +167,7 @@ Archiver.prototype._normalizeEntryData = function(data, stats) {
   data = util.defaults(data, {
     type: 'file',
     name: null,
-    date: null,
+    date: this.options.date,
     mode: null,
     sourcePath: null,
     stats: false


### PR DESCRIPTION
Set all files with `date` mtime. It is usefull for getting the same md5 when object rebuild.