### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/archiverjs/node-archiver/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/archiverjs/node-archiver/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "lib/archiver.js",
   "files": [
     "lib",


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license