### PR TITLE
Addressing issue #136 by ensuring directories are executable when created on Windows

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -30,6 +30,7 @@ var Archiver = module.exports = function(options) {
   this._module = false;
   this._pending = 0;
   this._pointer = 0;
+  this._isWin = /^win/.test(process.platform);
 
   this._queue = async.queue(this._onQueueTask.bind(this), 1);
   this._queue.drain = this._onQueueDrain.bind(this);
@@ -194,6 +195,10 @@ Archiver.prototype._normalizeEntryData = function(data, stats) {
     data.mode &= 0777;
   } else if (data.stats && data.mode === null) {
     data.mode = data.stats.mode & 0777;
+    // Ensure all directories are executable on Windows - https://github.com/archiverjs/node-archiver/issues/136
+    if(this._isWin && isDir) {
+      data.mode |= 0111;
+    }
   } else if (data.mode === null) {
     data.mode = isDir ? 0755 : 0644;
   }

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -267,7 +267,7 @@ describe('archiver', function() {
       });
 
       it('should retain directory permissions', function() {
-        assert.propertyVal(entries['subdir/'], 'mode', win32 ? 438 : 493);
+        assert.propertyVal(entries['subdir/'], 'mode', win32 ? 511 : 493);
       });
     });
   });

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -151,8 +151,8 @@ describe('plugins', function() {
       assert.propertyVal(entries['executable.sh'], 'externalFileAttributes', 2180972576);
       assert.equal((entries['executable.sh'].externalFileAttributes >>> 16) & 0xFFF, 511);
 
-      assert.propertyVal(entries['directory/subdir/'], 'externalFileAttributes', win32 ? 1102446608 : 1106051088);
-      assert.equal((entries['directory/subdir/'].externalFileAttributes >>> 16) & 0xFFF, win32 ? 438 : 493);
+      assert.propertyVal(entries['directory/subdir/'], 'externalFileAttributes', win32 ? 1107230736 : 1106051088);
+      assert.equal((entries['directory/subdir/'].externalFileAttributes >>> 16) & 0xFFF, win32 ? 511 : 493);
     });
 
     it('should allow for entry comments', function() {


### PR DESCRIPTION
Addresses: https://github.com/archiverjs/node-archiver/issues/136

Basically addresses this by ensuring all directories are executable when zips are created on Windows.

Not sure if a condition based on OS is the way you'd prefer to handle it, but if so the tests have also been updated and run on both Windows and Linux ;)