### PR TITLE
Added travis ci support for modern node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-- '5.0'
-- '4.0'
-- '0.12'
-- '0.10'
+  - 6
+  - 4
+  - '0.12'
+  - '0.10'
 matrix:
   fast_finish: true
 env:


### PR DESCRIPTION
Node 5 is not LTS so it was dropped.