### PR TITLE
feat(file): Add support for file special bits on unix

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -288,9 +288,17 @@ Archiver.prototype._normalizeEntryData = function(data, stats) {
 
   // 511 === 0777; 493 === 0755; 438 === 0666; 420 === 0644
   if (typeof data.mode === 'number') {
-    data.mode &= 511;
+    if (win32) {
+      data.mode &= 511;
+    } else {
+      data.mode &= 4095
+    }
   } else if (data.stats && data.mode === null) {
-    data.mode = data.stats.mode & 511;
+    if (win32) {
+      data.mode = data.stats.mode & 511;
+    } else {
+      data.mode = data.stats.mode & 4095;
+    }
 
     // stat isn't reliable on windows; force 0755 for dir
     if (win32 && isDir) {

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -42,6 +42,13 @@ describe('archiver', function() {
         var prefix2 = archive._normalizeEntryData({ name: 'entry.txt', prefix: '' });
         assert.propertyVal(prefix2, 'name', 'entry.txt');
       });
+
+      it('should support special bits on unix', function () {
+        if (!win32) {
+          var mode = archive._normalizeEntryData({ name: 'executable.sh', mode: fs.statSync('test/fixtures/executable.sh').mode });
+          assert.propertyVal(mode, 'mode', 511);
+        }
+      });
     });
   });
 


### PR DESCRIPTION
The current bitmask for files fails on unix for files with special bits set.