### PR TITLE
Add a `process.emitWarning` for `deprecated`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -58,6 +58,8 @@ var Archiver = function(format, options) {
   };
 
   this._streams = [];
+
+  this._loggedBulkDeprecation = false;
 };
 
 inherits(Archiver, Transform);
@@ -555,10 +557,13 @@ Archiver.prototype.append = function(source, data) {
  * @return {this}
  */
 Archiver.prototype.bulk = function(mappings) {
-  if (typeof process !== 'undefined' && typeof process.emitWarning !== 'undefined') {
-    process.emitWarning('Archiver.bulk() deprecated since 0.21.0', 'DeprecationWarning');
-  } else if (typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
-    console.warn('Archiver.bulk() deprecated since 0.21.0');
+  if (!this._loggedBulkDeprecation) {
+    this._loggedBulkDeprecation = true;
+    if (typeof process !== 'undefined' && typeof process.emitWarning !== 'undefined') {
+      process.emitWarning('Archiver.bulk() deprecated since 0.21.0', 'DeprecationWarning');
+    } else {
+      console.warn('Archiver.bulk() deprecated since 0.21.0');
+    }
   }
 
   if (this._state.finalize || this._state.aborted) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -559,10 +559,11 @@ Archiver.prototype.append = function(source, data) {
 Archiver.prototype.bulk = function(mappings) {
   if (!this._loggedBulkDeprecation) {
     this._loggedBulkDeprecation = true;
+    var warning = 'Archiver.bulk() deprecated since 0.21.0';
     if (typeof process !== 'undefined' && typeof process.emitWarning !== 'undefined') {
-      process.emitWarning('Archiver.bulk() deprecated since 0.21.0', 'DeprecationWarning');
+      process.emitWarning(warning, 'DeprecationWarning');
     } else {
-      console.warn('Archiver.bulk() deprecated since 0.21.0');
+      console.warn(warning);
     }
   }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -555,7 +555,11 @@ Archiver.prototype.append = function(source, data) {
  * @return {this}
  */
 Archiver.prototype.bulk = function(mappings) {
-  console.log('Archiver.bulk() deprecated since 0.21.0');
+  if (typeof process !== 'undefined' && typeof process.emitWarning !== 'undefined') {
+    process.emitWarning('Archiver.bulk() deprecated since 0.21.0', 'DeprecationWarning');
+  } else if (typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
+    console.warn('Archiver.bulk() deprecated since 0.21.0');
+  }
 
   if (this._state.finalize || this._state.aborted) {
     this.emit('error', new Error('bulk: queue closed'));

--- a/lib/core.js
+++ b/lib/core.js
@@ -555,6 +555,8 @@ Archiver.prototype.append = function(source, data) {
  * @return {this}
  */
 Archiver.prototype.bulk = function(mappings) {
+  console.log('Archiver.bulk() deprecated since 0.21.0');
+
   if (this._state.finalize || this._state.aborted) {
     this.emit('error', new Error('bulk: queue closed'));
     return this;


### PR DESCRIPTION
The Archiver.bulk() call has been deprecated for a while and various answers on SO and other sites still suggest it, so if there are no planned maintenance fixes and updates to that function, everyone (even those who do not read the docs) should be informed that they are using something that is deprecated.