### PR TITLE
Updated mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "archiver-jsdoc-theme": "^1.0.0",
     "jsdoc": "~3.4.0",
     "chai": "^3.4.0",
-    "mocha": "^2.3.3",
+    "mocha": "^3.1.1",
     "rimraf": "^2.4.2",
     "mkdirp": "^0.5.0",
     "stream-bench": "^0.1.2",


### PR DESCRIPTION
This should fix the deprecation warnings:

> npm WARN deprecated to-iso-string@0.0.2: to-iso-string has been deprecated, use @segment/to-iso-string instead.
> npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
> npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue