### PR TITLE
Emit errors on walk errors, not strings

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -649,8 +649,8 @@ Archiver.prototype.directory = function(dirpath, destpath, data) {
     this._maybeFinalize();
   }
 
-  function onWalkError(errMsg, err) {
-    this.emit('error', 'directory: ' + errMsg, err);
+  function onWalkError(filepath, err) {
+    this.emit('error', err);
   }
 
   var walker = walkdir(dirpath);

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -341,6 +341,23 @@ describe('archiver', function() {
               .file('test/fixtures/empty.txt')
               .finalize()
         });
+
+        it('should emit errors on missing directories', function(done) {
+            archive = archiver('json');
+            var testStream = new WriteStream('tmp/errors-stat.json');
+
+            archive.on('error', function (err) {
+                assert.typeOf(err, 'error')
+                assert.equal(err.code, 'ENOENT')
+                done();
+            })
+
+            archive.pipe(testStream);
+
+            archive
+                .directory('test/fixtures/missing-directory', false)
+                .finalize()
+        });
     });
   });
 });


### PR DESCRIPTION
When passing a path that does not exist, a string (`directory: /some/path`) would be emitted in the `error` event, instead of an error.

That was against what’s in the docs, and it is not really standard to pass something else than an error in an error handler.

Also, the string looks a lot like debug? Is it something that was left behind and forgotten there? The `lstat` error is actually better to understand what’s going on…