### PR TITLE
Issue #269: Add 'end' event documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,17 @@ var archive = archiver('zip', {
 });
 
 // listen for all archive data to be written
+// 'close' event is fired only when a file descriptor is involved
 output.on('close', function() {
   console.log(archive.pointer() + ' total bytes');
   console.log('archiver has been finalized and the output file descriptor has closed.');
+});
+
+// This event is fired when the data source is drained no matter what was the data source.
+// It is not part of this library but rather from the NodeJS Stream API.
+// @see: https://nodejs.org/api/stream.html#stream_event_end
+output.on('end', function() {
+  console.log('Data has been drained');
 });
 
 // good practice to catch warnings (ie stat failures and other non-blocking errors)
@@ -73,6 +81,7 @@ archive.directory('subdir/', false);
 archive.glob('subdir/*.txt');
 
 // finalize the archive (ie we are done appending files but streams have to finish yet)
+// 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
 archive.finalize();
 ```
 


### PR DESCRIPTION
Added a mention in the `Quick Start` section of the README.md documentation.