### PR TITLE
Fix relative symlink paths

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -495,8 +495,9 @@ Archiver.prototype._updateQueueTaskWithStats = function(task, stats) {
     task.source = new Buffer(0);
   } else if (stats.isSymbolicLink() && this._moduleSupports('symlink')) {
     var linkPath = fs.readlinkSync(task.filepath);
+    var dirName = path.dirname(task.filepath);
     task.data.type = 'symlink';
-    task.data.linkname = path.relative(path.dirname(task.filepath), path.resolve(linkPath));
+    task.data.linkname = path.relative(dirName, path.resolve(dirName, linkPath));
     task.data.sourceType = 'buffer';
     task.source = new Buffer(0);
   } else {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -23,8 +23,8 @@ describe('plugins', function() {
     if (!win32) {
       fs.chmodSync('test/fixtures/executable.sh', 0777);
       fs.chmodSync('test/fixtures/directory/subdir/', 0755);
-      fs.symlinkSync('test/fixtures/directory/level0.txt', 'test/fixtures/directory/subdir/level0link.txt');
-      fs.symlinkSync('test/fixtures/directory/subdir/subsub/', 'test/fixtures/directory/subdir/subsublink');
+      fs.symlinkSync('../level0.txt', 'test/fixtures/directory/subdir/level0link.txt');
+      fs.symlinkSync('subsub/', 'test/fixtures/directory/subdir/subsublink');
     } else {
       fs.writeFileSync('test/fixtures/directory/subdir/level0link.txt', '../level0.txt');
       fs.writeFileSync('test/fixtures/directory/subdir/subsublink', 'subsub');


### PR DESCRIPTION
I found a bug with relative symlinks.  The linkname would get confused and resolve to a relative path that included the location of my node.js server, that had nothing to do with the path of the symlink (either the symlink or the location of the file it pointed to).

For instance, I creeated a relative symlink named `thing2` inside the directory `/workspace`.
The symlink points to a file with absolute location of `/workspace/x/y/z/thing`, but the symlink is relative and so uses `x/y/z/thing`

The variables in scope of the changes work out as follows:
```
task.filepath == "/workspace/thing2"
linkpath ==  "x/y/z/thing"
```
BEFORE CHANGE: 
```
path.resolve(linkPath) == "/Users/jesse/dev/gravity/roles/spacegate/files/workspacesync/x/y/z/thing"
path.relative(...) == "../Users/jesse/dev/gravity/roles/spacegate/files/workspacesync/x/y/z/thing"
```
AFTER CHANGE:
```
path.relative(...) ==  "x/y/z/thing"
```