### PR TITLE
Correct the return value for .finalize()

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -757,7 +757,10 @@ Archiver.prototype.glob = function(pattern, options, data) {
  * right after calling this method so you should set listeners beforehand to
  * properly detect stream completion.
  *
- * @return {this}
+ * The return value is a `Promise` which will resolve once the `end` event
+ * has fired, or reject if there is an `error` event.
+ *
+ * @return {Promise}
  */
 Archiver.prototype.finalize = function() {
   if (this._state.aborted) {


### PR DESCRIPTION
The current JSDoc doesn't reflect the fact that a promise is returned by `finalize()`.

I hope that the description of when the promise resolves vs. when it rejects is correct.