### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -492,14 +492,14 @@ Archiver.prototype._updateQueueTaskWithStats = function(task, stats) {
     task.data.type = 'directory';
     task.data.sourcePath = util.trailingSlashIt(task.filepath);
     task.data.sourceType = 'buffer';
-    task.source = new Buffer(0);
+    task.source = Buffer.concat([]);
   } else if (stats.isSymbolicLink() && this._moduleSupports('symlink')) {
     var linkPath = fs.readlinkSync(task.filepath);
     var dirName = path.dirname(task.filepath);
     task.data.type = 'symlink';
     task.data.linkname = path.relative(dirName, path.resolve(dirName, linkPath));
     task.data.sourceType = 'buffer';
-    task.source = new Buffer(0);
+    task.source = Buffer.concat([]);
   } else {
     if (stats.isDirectory()) {
         this.emit('warning', new ArchiverError('DIRECTORYNOTSUPPORTED', task.data));
@@ -873,7 +873,7 @@ Archiver.prototype.symlink = function(filepath, target) {
   this._entriesCount++;
   this._queue.push({
     data: data,
-    source: new Buffer(0)
+    source: Buffer.concat([])
   });
 
   return this;


### PR DESCRIPTION
`Buffer.concat([])` returns an empty buffer all the way down to 0.8.x.

Alternative way would be to just use `Buffer.alloc(0)` and drop support for outdated Node.js versions (`< 4.5.0 || >= 5.0.0 < 5.10.0`).

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Tracking: https://github.com/nodejs/node/issues/19079