### PR TITLE
switch to specialized lodash.assign npm module

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -8,7 +8,7 @@
 var fs = require('fs');
 var glob = require('glob');
 var async = require('async');
-var _ = require('lodash');
+var _ = { extend: require('lodash.assign') };
 var path = require('path');
 var util = require('archiver-utils');
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "async": "^2.0.0",
     "buffer-crc32": "^0.2.1",
     "glob": "^7.0.0",
-    "lodash": "^4.8.0",
+    "lodash.assign": "^4.2.0",
     "readable-stream": "^2.0.0",
     "tar-stream": "^1.5.0",
     "zip-stream": "^1.2.0"


### PR DESCRIPTION
this optimizes node_modules size, reducing the carried node_modules dependencies by about (4.8 megabytes - 32 kilobytes)

Fixes #334 