### PR TITLE
Add new option to ignore file timestamps and produce archives with consistent hash

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -17,6 +17,13 @@ var Transform = require('readable-stream').Transform;
 
 var win32 = process.platform === 'win32';
 
+const ZERO_STATS = {};
+['atime', 'mtime', 'ctime', 'birthtime'].forEach((field) => {
+  ZERO_STATS[field] = new Date(0);
+  ZERO_STATS[field + 'Ms'] = 0;
+  ZERO_STATS[field + 'Ns'] = 0;
+});
+
 /**
  * @constructor
  * @param {String} format The archive format to use.
@@ -34,7 +41,8 @@ var Archiver = function(format, options) {
 
   options = this.options = util.defaults(options, {
     highWaterMark: 1024 * 1024,
-    statConcurrency: 4
+    statConcurrency: 4,
+    noTimestamps: false
   });
 
   Transform.call(this, options);
@@ -339,7 +347,12 @@ Archiver.prototype._normalizeEntryData = function(data, stats) {
     data.mode = isDir ? 493 : 420;
   }
 
-  if (data.stats && data.date === null) {
+  if (this.options.noTimestamps) {
+    data.date = new Date(0);
+    if (data.stats) {
+      data.stats = Object.assign(data.stats, ZERO_STATS);
+    }
+  } else if (data.stats && data.date === null) {
     data.date = data.stats.mtime;
   } else {
     data.date = util.dateify(data.date);
@@ -936,6 +949,8 @@ module.exports = Archiver;
  * @property {Boolean} [objectMode=false] Whether this stream should behave as a
  * stream of objects. Meaning that stream.read(n) returns a single value instead
  * of a Buffer of size n. `Readable` `Writable`
+ * @property {Boolean} [noTimestamps=false] Then enabled forces archiver to ignore
+ * timestamps of files
  */
 
 /**

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -153,6 +153,44 @@ describe('archiver', function() {
       });
     });
 
+    describe('#options.noTimestamp', function() {
+      var actual;
+      var archive;
+      var entries = {};
+
+      before(function(done) {
+        archive = archiver('json', { noTimestamps: true });
+        var testStream = new WriteStream('tmp/append.json');
+
+        testStream.on('close', function() {
+          actual = helpers.readJSON('tmp/append.json');
+
+          actual.forEach(function(entry) {
+            entries[entry.name] = entry;
+          });
+
+          done();
+        });
+
+        archive.pipe(testStream);
+
+        archive
+          .append(testBuffer, { name: 'buffer.txt', date: testDate })
+          .append(fs.createReadStream('test/fixtures/test.txt'), { name: 'stream.txt', date: testDate })
+          .finalize();
+      });
+
+      it('should reset date to zero for buffer', function() {
+        assert.property(entries, 'buffer.txt');
+        assert.propertyVal(entries['buffer.txt'], 'date', '1970-01-01T00:00:00.000Z');
+      });
+
+      it('should reset date to zero for buffer for stream', function() {
+        assert.property(entries, 'stream.txt');
+        assert.propertyVal(entries['stream.txt'], 'date', '1970-01-01T00:00:00.000Z');
+      });
+    });
+
     describe('#directory', function() {
       var actual;
       var archive;


### PR DESCRIPTION
Related to the following issue
https://github.com/archiverjs/node-archiver/issues/416