### PR TITLE
force bump tar-stream from 2.1.2 to 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "buffer-crc32": "^0.2.1",
     "readable-stream": "^3.6.0",
     "readdir-glob": "^1.0.0",
-    "tar-stream": "^2.1.2",
+    "tar-stream": "^2.1.4",
     "zip-stream": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
since its a security issue we can force it to atleast the most secure version known right now