### PR TITLE
Fix glob() `options` parameter's link

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -717,7 +717,7 @@ Archiver.prototype.file = function(filepath, data) {
  * Appends multiple files that match a glob pattern.
  *
  * @param  {String} pattern The [glob pattern]{@link https://github.com/isaacs/minimatch} to match.
- * @param  {Object} options See [node-glob]{@link https://github.com/yqnn/node-readdir-glob#options}.
+ * @param  {Object} options See [node-readdir-glob]{@link https://github.com/yqnn/node-readdir-glob#options}.
  * @param  {EntryData} data See also [ZipEntryData]{@link ZipEntryData} and
  * [TarEntryData]{@link TarEntryData}.
  * @return {this}


### PR DESCRIPTION
*node-archiver* doesn't use *node-glob*.