### PR TITLE
add isRegisteredFormat method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,6 @@ Archiver ships with out of the box support for TAR and ZIP archives.
 
 You can register additional formats with `registerFormat`.
 
+You can check if format already exists before to register a new one with `isRegisteredFormat`.
+
 _Formats will be changing in the future to implement a middleware approach._

--- a/index.js
+++ b/index.js
@@ -63,6 +63,20 @@ vending.registerFormat = function(format, module) {
   formats[format] = module;
 };
 
+/**
+ * Check if the format is already registered.
+ * 
+ * @param {String} format the name of the format.
+ * @return boolean
+ */
+vending.isRegisteredFormat = function (format) {
+  if (formats[format]) {
+    return true;
+  }
+  
+  return false;
+};
+
 vending.registerFormat('zip', require('./lib/plugins/zip'));
 vending.registerFormat('tar', require('./lib/plugins/tar'));
 vending.registerFormat('json', require('./lib/plugins/json'));

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -389,5 +389,13 @@ describe('archiver', function() {
           archive.finalize()
       });        
     });
+
+    describe('#isRegisteredFormat', function () {
+      var isRegisteredFormat = archiver.isRegisteredFormat('zip');
+      it('should return true when the value is present', function () {
+        assert.equal(true, isRegisteredFormat);
+      });
+    });
+    
   });
 });


### PR DESCRIPTION
Adding a check if the format is already registered. It useful, if you are using the method `registerFormat() `explicitly, to avoid the error _**"..format already registered",**_ you can check if the format exists using `isRegisteredFormat(format)`, if not, you can register the new one.

Related to the  following issue #461
