### PR TITLE
support directory symlinks

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -190,6 +190,10 @@ Archiver.prototype._moduleAppend = function(source, data, callback) {
       return;
     }
 
+    if (data.type === 'symlink' && data.name.slice(-1) === "/") {
+      data.name = data.name.slice(0, -1);
+    }
+
     /**
      * Fires when the entry's input has been processed and appended to the archive.
      *
@@ -864,6 +868,14 @@ Archiver.prototype.symlink = function(filepath, target) {
 
   if (typeof target !== 'string' || target.length === 0) {
     this.emit('error', new ArchiverError('SYMLINKTARGETREQUIRED', { filepath: filepath }));
+    return this;
+  }
+
+  var filepathHasTrailingSlash = filepath.slice(-1) === '/';
+  var targetHasTrailingSlash = target.slice(-1) === '/';
+
+  if ((filepathHasTrailingSlash && !targetHasTrailingSlash) || (!filepathHasTrailingSlash && targetHasTrailingSlash)) {
+    this.emit('error', new ArchiverError("SYMLINKDIRECTORYSUFFIXESMISMATCHED", { filepath: filepath, target: target }))
     return this;
   }
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -24,6 +24,7 @@ const ERROR_CODES = {
   'SYMLINKNOTSUPPORTED': 'support for symlink entries not defined by module',
   'SYMLINKFILEPATHREQUIRED': 'symlink filepath argument must be a non-empty string value',
   'SYMLINKTARGETREQUIRED': 'symlink target argument must be a non-empty string value',
+  'SYMLINKDIRECTORYSUFFIXESMISMATCHED': 'directory symlink arguments must both have / suffixes',
   'ENTRYNOTSUPPORTED': 'entry not supported'
 };
 

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -288,6 +288,42 @@ describe('archiver', function() {
       });
     });
 
+    describe('#symlink', function() {
+      var actual;
+      var archive;
+      var entries = {};
+
+      before(function(done) {
+        archive = archiver('json');
+        var testStream = new WriteStream('tmp/symlink.json');
+
+        testStream.on('close', function() {
+          actual = helpers.readJSON('tmp/symlink.json');
+
+          actual.forEach(function(entry) {
+            entries[entry.name] = entry;
+          });
+
+          done();
+        });
+
+        archive.pipe(testStream);
+
+        archive
+          .append("file-a", { name: "file-a" })
+          .symlink("directory-a/symlink-to-file-a", "../file-a")
+          .symlink("directory-b/directory-c/symlink-to-directory-a/", "../../directory-a/")
+          .finalize();
+      });
+
+      it('should append multiple entries', () => {
+        assert.isArray(actual);
+        assert.property(entries, 'file-a');
+        assert.property(entries, 'directory-a/symlink-to-file-a');
+        assert.property(entries, 'directory-b/directory-c/symlink-to-directory-a');
+      });
+    });
+
     describe('#glob', function() {
       var actual;
       var archive;

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -167,6 +167,7 @@ describe('plugins', function() {
         .file('test/fixtures/executable.sh', { name: 'executable.sh', mode: win32 ? 0777 : null })
         .directory('test/fixtures/directory', 'directory')
         .symlink('manual-link.txt', 'manual-link-target.txt')
+        .symlink('dir-symlink-test/nested/symlink-to-subsub/', '../../directory/subdir/subsub/')
         .finalize();
     });
 
@@ -203,6 +204,12 @@ describe('plugins', function() {
         assert.property(entries, 'manual-link.txt');
         assert.propertyVal(entries['manual-link.txt'], 'crc32', 1121667014);
         assert.propertyVal(entries['manual-link.txt'], 'externalFileAttributes', 2684354592);
+    });
+
+    it('should append manual directory symlink', function() {
+      assert.property(entries, 'dir-symlink-test/nested/symlink-to-subsub');
+      assert.propertyVal(entries['dir-symlink-test/nested/symlink-to-subsub'], 'externalFileAttributes', 2733834272);
+      assert.equal((entries['dir-symlink-test/nested/symlink-to-subsub'].externalFileAttributes >>> 16) & 0xFFF, 755);
     });
 
     it('should allow for custom unix mode', function() {


### PR DESCRIPTION
This depends on the PR I to `zip-stream` earlier: https://github.com/archiverjs/node-zip-stream/pull/68 

It adds tests for symlinks and also adds a specific error code to document that if you add a trailing slash to either argument to `symlink` then you should add it to both. I've also ensured that the trailing slash is removed before the entry is emitted, to retain consistency with other entry types.