### PR TITLE
add mode parameter to symlink

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -849,9 +849,10 @@ Archiver.prototype.setModule = function(module) {
  *
  * @param  {String} filepath The symlink path (within archive).
  * @param  {String} target The target path (within archive).
+ * @param  {Number} mode Sets the entry permissions.
  * @return {this}
  */
-Archiver.prototype.symlink = function(filepath, target) {
+Archiver.prototype.symlink = function(filepath, target, mode) {
   if (this._state.finalize || this._state.aborted) {
     this.emit('error', new ArchiverError('QUEUECLOSED'));
     return this;
@@ -877,6 +878,10 @@ Archiver.prototype.symlink = function(filepath, target) {
   data.name = filepath.replace(/\\/g, '/');
   data.linkname = target.replace(/\\/g, '/');
   data.sourceType = 'buffer';
+
+  if (typeof mode === "number") {
+    data.mode = mode;
+  }
 
   this._entriesCount++;
   this._queue.push({


### PR DESCRIPTION
I recently opened these PRs:

https://github.com/archiverjs/node-archiver/pull/468
https://github.com/archiverjs/node-zip-stream/pull/68

But I had a rethink and I think this is a better approach. It just exposes the mode as an optional argument to `symlink`. Setting the mode to `493` for directory symlinks does exactly what I need, and also allows other users to control the permissions however they want.