### PR TITLE
Finalize should always return a promise

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -769,13 +769,15 @@ Archiver.prototype.glob = function(pattern, options, data) {
  */
 Archiver.prototype.finalize = function() {
   if (this._state.aborted) {
-    this.emit('error', new ArchiverError('ABORTED'));
-    return this;
+    var abortedError = new ArchiverError('ABORTED');
+    this.emit('error', abortedError);
+    return Promise.reject(abortedError);
   }
 
   if (this._state.finalize) {
-    this.emit('error', new ArchiverError('FINALIZING'));
-    return this;
+    var finalizingError = new ArchiverError('FINALIZING');
+    this.emit('error', finalizingError);
+    return Promise.reject(finalizingError);
   }
 
   this._state.finalize = true;


### PR DESCRIPTION
In case of error, the promise should be rejected rather than returning the `this` object. The problem is discussed in detail here 👉  https://github.com/archiverjs/node-archiver/issues/344.