### PR TITLE
Add glob method's options.cwd to API docs

### DIFF
--- a/website/docs/archiver_api.md
+++ b/website/docs/archiver_api.md
@@ -142,7 +142,7 @@ Appends multiple files that match a glob pattern.
 ##### Parameters
 
 - `pattern` - *String* - The [glob pattern](https://github.com/isaacs/minimatch) to match.
-- `options` - *Object* - See [node-readdir-glob](https://github.com/yqnn/node-readdir-glob#options).
+- `options` - *Object* - Options passed to [node-readdir-glob](https://github.com/yqnn/node-readdir-glob#options), plus an optional `cwd` property that sets the directory to read (defaults to `'.'`).
 - `data` - *Object* - [The entry data](#entry-data).
 
 ---


### PR DESCRIPTION
In addition to the options supported by `node-readdir-glob`, `archiver` supports an additional `cwd` option that was only documented in example code in the quick start. This PR adds it to the API reference.