### PR TITLE
Added helper compress function.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -594,6 +594,30 @@ Archiver.prototype.append = function(source, data) {
 };
 
 /**
+ * A general compress function that checks whether the given path is a file or directory
+ * and adds data to the archive accordingly, then compresses it.
+ *
+ * @param {String} [inputPath] Path of file or folder of data to be compressed.
+ * @param {String} [outputPath] Path of where to save the archive.
+ * @return {this}
+ */
+Archiver.prototype.compress = function(inputPath, outputPath) {
+  const output = fs.createWriteStream(outputPath);
+  this.pipe(output);
+  fs.stat(inputPath, (err, stats) => {
+    if (err) {
+      return;
+    }
+    if (stats.isDirectory()) {
+      this.directory(inputPath);
+    } else if (stats.isFile()) {
+      this.file(inputPath, { name: path.basename(inputPath) });
+    }
+    this.finalize();
+  });
+};
+
+/**
  * Appends a directory and its files, recursively, given its dirpath.
  *
  * @param  {String} dirpath The source directory path.


### PR DESCRIPTION
This is a helper function for more shorthand compression. It detects whether the data  its compressing is a file or a directory, and uses the appropriate functions based on that. Here's a usage example:

```
const archive = archiver('zip');
archive.compress('dir/', 'archive.zip');
```

fs is already a dependency, so it skips the step of manually passing in the file input stream.

Without this helper function, say I want to compress a directory. In the example, I am to do it as so:

```
// require modules
const fs = require('fs');
const archiver = require('archiver');

// create a file to stream archive data to.
const output = fs.createWriteStream(__dirname + '/example.zip');
const archive = archiver('zip', {
  zlib: { level: 9 } // Sets the compression level.
});

// pipe archive data to the file
archive.pipe(output);

// append files from a sub-directory and naming it `new-subdir` within the archive
archive.directory('subdir/', 'new-subdir');
archive.finalize();
```

This is quite verbose, just to compress a directory. This function makes it so it can be done in one line.