### PR TITLE
use `node:protocol`, remove legacy readable-stream and remove `is-stream` microutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install archiver --save
 ## Quick Start
 
 ```js
-import fs from "fs";
+import fs from "node:fs";
 import { ZipArchive } from "archiver";
 
 // create a file to stream archive data to.

--- a/benchmark/simple/pack-zip.js
+++ b/benchmark/simple/pack-zip.js
@@ -1,4 +1,4 @@
-var fs = require("fs");
+var fs = require("node:fs");
 
 var mkdir = require("mkdirp");
 var streamBench = require("stream-bench");

--- a/examples/pack-tar.js
+++ b/examples/pack-tar.js
@@ -1,4 +1,4 @@
-var fs = require("fs");
+var fs = require("node:fs");
 
 var archiver = require("archiver");
 

--- a/examples/pack-tgz.js
+++ b/examples/pack-tgz.js
@@ -1,4 +1,4 @@
-var fs = require("fs");
+var fs = require("node:fs");
 var archiver = require("archiver");
 
 var output = fs.createWriteStream(__dirname + "/example-output.tar.gz");

--- a/examples/pack-zip.js
+++ b/examples/pack-zip.js
@@ -1,4 +1,4 @@
-var fs = require("fs");
+var fs = require("node:fs");
 
 var archiver = require("archiver");
 

--- a/examples/progress.js
+++ b/examples/progress.js
@@ -1,7 +1,7 @@
 var archiver = require("../");
-var tmp = require("os").tmpdir();
+var tmp = require("node:os").tmpdir();
 var async = require("async");
-var fs = require("fs");
+var fs = require("node:fs");
 
 // You can change this by something bigger!
 var directory = __dirname + "/fixtures";

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,5 +1,5 @@
-import { createReadStream, lstat, readlinkSync, Stats } from "fs";
-import { isStream } from "is-stream";
+import { createReadStream, lstat, readlinkSync, Stats } from "node:fs";
+import { isStream } from "./utils.js";
 import readdirGlob from "readdir-glob";
 import { Readable } from "lazystream";
 import { queue } from "async";
@@ -9,7 +9,7 @@ import {
   resolve as resolvePath,
 } from "path";
 import { ArchiverError } from "./error.js";
-import { Transform } from "readable-stream";
+import { Transform } from "node:stream";
 import {
   dateify,
   normalizeInputSource,

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,4 +1,4 @@
-import util from "util";
+import util from "node:util";
 
 const ERROR_CODES = {
   ABORTED: "archive was aborted",

--- a/lib/plugins/json.js
+++ b/lib/plugins/json.js
@@ -1,4 +1,4 @@
-import { Transform } from "readable-stream";
+import { Transform } from "node:stream";
 import crc32 from "buffer-crc32";
 import { collectStream } from "../utils.js";
 

--- a/lib/plugins/tar.js
+++ b/lib/plugins/tar.js
@@ -1,4 +1,4 @@
-import zlib from "zlib";
+import zlib from "node:zlib";
 import engine from "tar-stream";
 import { collectStream } from "../utils.js";
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,5 @@
 import normalizePath from "normalize-path";
-import { PassThrough } from "readable-stream";
-import { isStream } from "is-stream";
+import { PassThrough } from "node:stream";
 
 export function collectStream(source, callback) {
   var collection = [];
@@ -63,4 +62,10 @@ export function sanitizePath(filepath) {
 
 export function trailingSlashIt(str) {
   return str.slice(-1) !== "/" ? str + "/" : str;
+}
+
+export function isStream(stream) {
+	return stream !== null
+		&& typeof stream === 'object'
+		&& typeof stream.pipe === 'function';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,8 @@
       "dependencies": {
         "async": "^3.2.4",
         "buffer-crc32": "^1.0.0",
-        "is-stream": "^3.0.0",
         "lazystream": "^1.0.0",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0",
         "readdir-glob": "^1.1.3",
         "tar-stream": "^3.0.0",
         "zip-stream": "^7.0.2"
@@ -991,17 +989,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1408,6 +1395,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2917,11 +2905,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
-    },
-    "is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
     },
     "is-unicode-supported": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,8 @@
   "dependencies": {
     "async": "^3.2.4",
     "buffer-crc32": "^1.0.0",
-    "is-stream": "^3.0.0",
     "lazystream": "^1.0.0",
     "normalize-path": "^3.0.0",
-    "readable-stream": "^4.0.0",
     "readdir-glob": "^1.1.3",
     "tar-stream": "^3.0.0",
     "zip-stream": "^7.0.2"

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -7,9 +7,8 @@ import {
   symlinkSync,
   unlinkSync,
   writeFileSync,
-} from "fs";
-import { PassThrough } from "readable-stream";
-import { Readable } from "readable-stream";
+} from "node:fs";
+import { Readable } from "node:stream";
 import { assert } from "chai";
 import { mkdirp } from "mkdirp";
 import {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,8 +1,7 @@
-import crypto from "crypto";
-import { readFileSync, WriteStream } from "fs";
-import { inherits } from "util";
-import { Stream } from "stream";
-import { Readable, Writable } from "readable-stream";
+import crypto from "node:crypto";
+import { readFileSync, WriteStream } from "node:fs";
+import { inherits } from "node:util";
+import { Stream, Readable, Writable } from "node:stream";
 
 export function adjustDateByOffset(d, offset) {
   d = d instanceof Date ? d : new Date();

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -5,7 +5,7 @@ import {
   unlinkSync,
   writeFileSync,
   WriteStream,
-} from "fs";
+} from "node:fs";
 import { assert } from "chai";
 import { mkdirp } from "mkdirp";
 import tar from "tar";

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -13,7 +13,7 @@ Archiver is available on [npm](https://www.npmjs.com/package/archiver).
 
 ```js
 // require modules
-const fs = require("fs");
+const fs = require("node:fs");
 const archiver = require("archiver");
 
 // create a file to stream archive data to.


### PR DESCRIPTION
fixes #765, #773 

removes dependency on `readable-stream` and `is-stream`. The first is legacy and is not needed, the second is a micro-util that can be replaced with 3 lines of code.

All 40 tests pass, the change is fully backwards-compatible since min node version is 18.