### PR TITLE
{WIP} - Add an option to allow to follow the symlinks

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -592,6 +592,7 @@ export default class Archiver extends Transform {
     var globOptions = {
       stat: true,
       dot: true,
+      follow: this._options?.followSymLinks,
     };
     function onGlobEnd() {
       this._pending--;
@@ -799,6 +800,7 @@ export default class Archiver extends Transform {
  * @global
  * @property {Number} [statConcurrency=4] Sets the number of workers used to
  * process the internal fs stat queue.
+ * @property {Boolean} [followSymLinks=false] Sets whether to follow symlinks.
  */
 
 /**


### PR DESCRIPTION
This change will allow to pass an addtional `option` when creating an `archiver` object to allow to follow the symlinks so the target folders and files of the symlinks will be archived instead of the symlinks.

The usage will be something like:
```js
const archive = archiver("zip", {
  zlib: { level: 9 }, // Sets the compression level.
  followSymlinks: true
});
```
