### PR TITLE
Quality: collectStream callback invoked twice on error-prone streams

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,8 +5,13 @@ import { isStream } from "is-stream";
 export function collectStream(source, callback) {
   var collection = [];
   var size = 0;
+  var done = false;
 
-  source.on("error", callback);
+  source.on("error", function (err) {
+    if (done) return;
+    done = true;
+    callback(err);
+  });
 
   source.on("data", function (chunk) {
     collection.push(chunk);
@@ -14,6 +19,9 @@ export function collectStream(source, callback) {
   });
 
   source.on("end", function () {
+    if (done) return;
+    done = true;
+
     var buf = Buffer.alloc(size);
     var offset = 0;
 


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The collectStream function registers separate listeners for 'error' and 'end' events that both call the same callback, with no guard preventing double invocation. While standard Node.js streams should not emit 'end' after 'error', this library processes arbitrary external streams (user-supplied), and non-standard stream implementations can violate this contract. If the callback is called twice (e.g., first with an error, then with data), downstream code may attempt to use a destroyed resource, call res.send() after headers are sent, or corrupt archive state — causing production crashes that are difficult to diagnose.


**Severity**: `medium`
**File**: `lib/utils.js`

### Solution
Add a `done` flag to ensure the callback is only invoked once:

export function collectStream(source, callback) {
  var collection = [];
  var size = 0;
  var done = false;

  source.on("error", function (err) {
    if (done) return;
    done = true;
    callback(err);
  });

  source.on("data", function (chunk) {
    collection.push(chunk);
    size += chunk.length;
  });

  source.on("end", function () {
    if (done) return;
    done = true;

    var buf = Buffer.alloc(size);
    var offset = 0;

    collection.forEach(function (data) {
      data.copy(buf, offset);
      offset += data.length;
    });

    callback(null, buf);
  });
}


### Changes
- `lib/utils.js` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #853