### PR TITLE
fix(zip): translate forceUTC option to forceLocalTime for zip-stream

### DIFF
--- a/lib/plugins/zip.js
+++ b/lib/plugins/zip.js
@@ -21,11 +21,16 @@ export default class Zip {
   constructor(options) {
     options = this.options = {
       comment: "",
-      forceUTC: false,
       namePrependSlash: false,
       store: false,
       ...options,
     };
+    if (
+      typeof options.forceUTC === "boolean" &&
+      typeof options.forceLocalTime === "undefined"
+    ) {
+      options.forceLocalTime = !options.forceUTC;
+    }
     this.engine = new engine(options);
   }
   /**

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -256,5 +256,18 @@ describe("plugins", function () {
     it("should allow for archive comment", function () {
       assert.equal("archive comment", zipComment);
     });
+    it("should translate forceUTC option to forceLocalTime on engine", function () {
+      var zipUtc = new ZipArchive({ forceUTC: true });
+      assert.equal(zipUtc._module.options.forceLocalTime, false);
+
+      var zipLocal = new ZipArchive({ forceUTC: false });
+      assert.equal(zipLocal._module.options.forceLocalTime, true);
+
+      var zipExplicitLocal = new ZipArchive({
+        forceLocalTime: true,
+        forceUTC: true,
+      });
+      assert.equal(zipExplicitLocal._module.options.forceLocalTime, true);
+    });
   });
 });


### PR DESCRIPTION
## Problem
`archiver` exposes `forceUTC` in its options and documentation, but `zip-stream` internally checks `options.forceLocalTime`. Without translation, passing `forceUTC: true` or `forceUTC: false` was not properly mapped to `forceLocalTime` on `zip-stream`.

## Solution
1. In `lib/plugins/zip.js`, added translation logic to map `options.forceUTC` to `options.forceLocalTime = !options.forceUTC` when `forceLocalTime` is not explicitly provided.
2. If `options.forceLocalTime` is explicitly provided, it continues to take precedence.
3. Added unit test in `test/plugins.js` verifying the option translation.

## Verification
- Ran `npx prettier --write lib/plugins/zip.js test/plugins.js`.
- Ran `npm test`, all tests passing.

Fixes #843
