### PR TITLE
refactor: use node:-prefixed imports for Node.js core modules

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1,4 +1,4 @@
-import { createReadStream, lstat, readlinkSync, Stats } from "fs";
+import { createReadStream, lstat, readlinkSync, Stats } from "node:fs";
 import { isStream } from "is-stream";
 import readdirGlob from "readdir-glob";
 import { Readable } from "lazystream";
@@ -7,7 +7,9 @@ import {
   dirname,
   relative as relativePath,
   resolve as resolvePath,
-} from "path";
+} from "node:path";
+import process from "node:process";
+import { Buffer } from "node:buffer";
 import { ArchiverError } from "./error.js";
 import { Transform } from "readable-stream";
 import {

--- a/lib/plugins/tar.js
+++ b/lib/plugins/tar.js
@@ -1,4 +1,4 @@
-import zlib from "zlib";
+import zlib from "node:zlib";
 import engine from "tar-stream";
 import { collectStream } from "../utils.js";
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import normalizePath from "normalize-path";
 import { PassThrough } from "readable-stream";
 import { isStream } from "is-stream";

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -7,7 +7,8 @@ import {
   symlinkSync,
   unlinkSync,
   writeFileSync,
-} from "fs";
+} from "node:fs";
+import process from "node:process";
 import { PassThrough } from "readable-stream";
 import { Readable } from "readable-stream";
 import { assert } from "chai";

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,7 +1,8 @@
-import crypto from "crypto";
-import { readFileSync, WriteStream } from "fs";
-import { inherits } from "util";
-import { Stream } from "stream";
+import crypto from "node:crypto";
+import { readFileSync, WriteStream } from "node:fs";
+import { inherits } from "node:util";
+import { Stream } from "node:stream";
+import { Buffer } from "node:buffer";
 import { Readable, Writable } from "readable-stream";
 
 export function adjustDateByOffset(d, offset) {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -5,7 +5,8 @@ import {
   unlinkSync,
   writeFileSync,
   WriteStream,
-} from "fs";
+} from "node:fs";
+import process from "node:process";
 import { assert } from "chai";
 import { mkdirp } from "mkdirp";
 import tar from "tar";


### PR DESCRIPTION
## Problem
Node.js core modules were imported using bare specifiers (e.g. `import { ... } from "fs"`). In modern JavaScript environments, including Cloudflare Workers Runtime, Deno, and modern bundlers, built-in Node modules require or strongly encourage using the explicit `node:` protocol prefix.

## Solution
Updated all Node.js built-in module imports (`fs`, `path`, `process`, `zlib`, `crypto`, `util`, `stream`, `buffer`, `events`) across `lib/` and `test/` to use the `node:` prefix (e.g. `node:fs`, `node:path`, `node:zlib`, etc.).

## Verification
- Formatted with Prettier (`npx prettier --write lib/ test/`).
- Verified that all unit and integration tests run successfully with `npm test`.

Fixes #773
