### PR TITLE
feat(directory): add option to configure followSymlinks

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -589,9 +589,18 @@ export default class Archiver extends Transform {
     } else if (typeof data !== "object") {
       data = {};
     }
+
+    let followSymlinks = false;
+    if (typeof data.followSymlinks === "boolean") {
+      followSymlinks = data.followSymlinks;
+    } else if (typeof this.options.followSymlinks === "boolean") {
+      followSymlinks = this.options.followSymlinks;
+    }
+
     var globOptions = {
       stat: true,
       dot: true,
+      follow: followSymlinks,
     };
     function onGlobEnd() {
       this._pending--;

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -268,6 +268,34 @@ describe("archiver", function () {
         assert.property(entries, "Win/DS/level0.txt");
       });
     });
+    describe("#directory (followSymlinks)", function () {
+      var actual;
+      var archive;
+      var entries = {};
+      before(function (done) {
+        archive = new JsonArchive();
+        var testStream = new WriteStream("tmp/directory-followed.json");
+        testStream.on("close", function () {
+          actual = readJSON("tmp/directory-followed.json");
+          actual.forEach(function (entry) {
+            entries[entry.name] = entry;
+          });
+          done();
+        });
+        archive.pipe(testStream);
+        archive
+          .directory("test/fixtures/directory", "followed", {
+            followSymlinks: true,
+          })
+          .finalize();
+      });
+      it("should support followSymlinks: true option", function () {
+        assert.property(entries, "followed/subdir/level0link.txt");
+        if (!win32) {
+          assert.equal(entries["followed/subdir/level0link.txt"].type, "file");
+        }
+      });
+    });
     describe("#file", function () {
       var actual;
       var archive;


### PR DESCRIPTION
## Problem
When using the `directory()` method, callers had no explicit option to configure whether symlinks within directories should be followed (resolving target file contents) or retained as symbolic link entries.

## Solution
1. Added support for `followSymlinks` option in `directory(dirpath, destpath, data)` (passed via `data.followSymlinks`) and in `CoreOptions` on the `Archiver` instance (`options.followSymlinks`).
2. Configured `readdirGlob` with `follow: followSymlinks` so symlink resolution behavior is cleanly configurable.
3. Added test coverage in `test/archiver.js`.

## Verification
- Formatted code using Prettier (`npx prettier --write lib/core.js test/archiver.js`).
- Executed `npm test`, all 40 tests passing.

Fixes #808
