### PR TITLE
fix(utils): allow entry names with backslash without collapsing to empty string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,9 +56,15 @@ export function normalizeInputSource(source) {
 }
 
 export function sanitizePath(filepath) {
-  return normalizePath(filepath, false)
+  var sanitized = normalizePath(filepath, false)
     .replace(/^\w+:/, "")
     .replace(/^(\.\.\/|\/)+/, "");
+
+  if (sanitized.length === 0 && filepath.length > 0) {
+    return filepath;
+  }
+
+  return sanitized;
 }
 
 export function trailingSlashIt(str) {

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -189,6 +189,18 @@ describe("archiver", function () {
         assert.propertyVal(entries["directory/"], "crc32", 0);
         assert.propertyVal(entries["directory/"], "size", 0);
       });
+      it("should allow appending an entry named '\\'", function (done) {
+        var archive = new JsonArchive();
+        var stream = new WriteStream("tmp/append-backslash.json");
+        stream.on("close", function () {
+          var res = readJSON("tmp/append-backslash.json");
+          assert.equal(res[0].name, "\\");
+          assert.equal(res[0].type, "file");
+          done();
+        });
+        archive.pipe(stream);
+        archive.append("test content", { name: "\\" }).finalize();
+      });
     });
     describe("#directory", function () {
       var actual;


### PR DESCRIPTION
## Problem
When appending an entry named `"\\"` (e.g. `archive.append('hello', { name: '\\' })`), `sanitizePath` normalized `"\\"` to `"/"` and subsequently stripped leading slashes, converting the filename to an empty string `""`. This resulted in `ArchiverError: entry name must be a non-empty string value`.

## Solution
1. Updated `sanitizePath` in `lib/utils.js` so that if the sanitized string produces an empty result but the original input `filepath` was non-empty (such as `name: "\\"`), the original `filepath` is preserved.
2. Added unit test in `test/archiver.js` verifying that appending a file named `"\\"` succeeds.

## Verification
- Formatted using Prettier (`npx prettier --write lib/utils.js test/archiver.js`).
- Verified that all unit tests pass with `npm test`.

Fixes #743
