### PR TITLE
chore: remove unused rimraf dependency and fix zlib doc links

### DIFF
--- a/lib/plugins/zip.js
+++ b/lib/plugins/zip.js
@@ -16,7 +16,7 @@ export default class Zip {
    * @param {Boolean} [options.forceZip64=false] Forces the archive to contain ZIP64 headers.
    * @param {Boolean} [options.namePrependSlash=false] Prepends a forward slash to archive file paths.
    * @param {Boolean} [options.store=false] Sets the compression method to STORE.
-   * @param {Object} [options.zlib] Passed to [zlib]{@link https://nodejs.org/api/zlib.html#zlib_class_options}
+   * @param {Object} [options.zlib] Passed to [zlib]{@link https://nodejs.org/api/zlib.html#class-options}
    */
   constructor(options) {
     options = this.options = {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "mkdirp": "3.0.1",
     "mocha": "11.7.5",
     "prettier": "3.8.3",
-    "rimraf": "6.1.3",
     "stream-bench": "0.1.2",
     "tar": "6.2.1",
     "yauzl": "3.3.0"

--- a/website/docs/archiver_api.md
+++ b/website/docs/archiver_api.md
@@ -32,12 +32,12 @@ The `options` object may include the following properties as well as all [Stream
 - `forceZip64` - _Boolean_ - Forces the archive to contain ZIP64 headers.
 - `namePrependSlash` - _Boolean_ - Prepends a forward slash to archive file paths.
 - `store` - _Boolean_ - Sets the compression method to STORE.
-- `zlib` - _Object_ - Passed to [zlib](https://nodejs.org/api/zlib.html#zlib_class_options) to control compression.
+- `zlib` - _Object_ - Passed to [zlib](https://nodejs.org/api/zlib.html#class-options) to control compression.
 
 ##### TAR Options
 
 - `gzip` - _Boolean_ - Compress the tar archive using gzip.
-- `gzipOptions` - _Object_ - Passed to [zlib](https://nodejs.org/api/zlib.html#zlib_class_options) to control compression.
+- `gzipOptions` - _Object_ - Passed to [zlib](https://nodejs.org/api/zlib.html#class-options) to control compression.
 
 See [tar-stream](https://www.npmjs.com/package/tar-stream) documentation for additional properties.
 


### PR DESCRIPTION
## Overview
Cleans up the unused `rimraf` dependency from `devDependencies` in `package.json` and updates outdated Node.js `zlib` documentation anchor links (`#zlib_class_options` -> `#class-options`).

## Changes
1. Removed `rimraf` from `package.json` `devDependencies` (native `node:fs` APIs are used across all test fixtures and source code).
2. Updated `zlib` documentation anchor links in `lib/plugins/zip.js` and `website/docs/archiver_api.md` to point to the current Node.js documentation anchor (`#class-options`).

## Verification
- Ran `npm test`, all 39 tests passing.
